### PR TITLE
Fix sandbox crash

### DIFF
--- a/src/ButterEquipped/ButterEquipped.csproj
+++ b/src/ButterEquipped/ButterEquipped.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Bannerlord.BUTRModule.Sdk/1.0.1.80">
 
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <TargetFramework>net472</TargetFramework>
     <Platforms>x64</Platforms>
     <LangVersion>latest</LangVersion>

--- a/src/ButterEquipped/SubModule.cs
+++ b/src/ButterEquipped/SubModule.cs
@@ -45,9 +45,17 @@ public class SubModule : MBSubModuleBase
 
         Options ??= new();
         campaignGameStarter.AddBehavior(eqUpBehavior = new AutoEquipBehavior(Options));
+    }
+
+    public override void OnAfterGameInitializationFinished(Game game, object starterObject)
+    {
+        if (game.GameType is not Campaign campaign)
+        {
+            return;
+        }
 
         Debug.Assert(settings is null);
-        var builder = Settings.EquipSettings.AddEquipSettings(Options, campaign.UniqueGameId);
+        var builder = Settings.EquipSettings.AddEquipSettings(Options!, campaign.UniqueGameId);
         settings = builder.BuildAsPerSave();
         settings?.Register();
     }


### PR DESCRIPTION
This avoids a crash because UniqueCampaignId is not set until OnGameInitializationFinished